### PR TITLE
Fixed CI Build Error Caused by rosparam_handler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ install(
 )
 
 install(
-        DIRECTORY include/rosparam_handler
+        DIRECTORY include/rosparam_handler/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 


### PR DESCRIPTION
Just to be clear, CI fails when trying to use rosparam handler on an external project.

Copy of #1 

Error:
```
Errors     << moveit_simple:make /root/catkin_ws/logs/moveit_simple/build.make.000.log
In file included from /root/catkin_ws/src/moveit_simple/moveit_simple/include/moveit_simple/moveit_simple.h:46:0,
                 from /root/catkin_ws/src/moveit_simple/moveit_simple/src/moveit_simple.cpp:19:
/root/catkin_ws/devel/.private/moveit_simple/include/moveit_simple/moveit_simple_dynamic_reconfigure_Parameters.h:13:42: fatal error: rosparam_handler/utilities.hpp: No such file or directory
 #include <rosparam_handler/utilities.hpp>
```